### PR TITLE
[28기 안현재][Add] 공통컴포넌트 - 트립카드 구현

### DIFF
--- a/src/components/TripCard/TripCard.js
+++ b/src/components/TripCard/TripCard.js
@@ -1,3 +1,60 @@
+import RadiusButton from '../Buttons/RadiusButton';
+import {
+  TripCardDiv,
+  TripCardGellery,
+  TripCardGelleryImg,
+  TripCardDescription,
+  TripCardGellerySocial,
+  TripCardGelleryShare,
+  TripCardDescriptionTitle,
+  TripCardDescriptionLocation,
+  TripCardDescriptionDate,
+  TripCardDescriptionAuthor,
+  TripCardDescriptionAuthorUserId,
+} from './TripCardStyles';
+
+const cardMockData = {
+  img_url:
+    'https://images.unsplash.com/profile-1446404465118-3a53b909cc82?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=27a346c2362207494baa7b76f5d606e5',
+  is_vote: true,
+  title: '여행지 추천드립니다~',
+  location: '슈투트가르트',
+  date: '2022.01.11',
+  user_id: '유저아이디',
+};
+
 export default function TripCard() {
-  return <>TripCard</>;
+  return (
+    <TripCardDiv>
+      <TripCardGellery>
+        <TripCardGelleryImg src={cardMockData.img_url} alt="갤러리" />
+        <TripCardGellerySocial>
+          <RadiusButton buttonType="faceBookIcon" />
+          <RadiusButton buttonType="twitterIcon" />
+          <RadiusButton buttonType="painterestIcon" />
+          <RadiusButton buttonType="linkedinIcon" />
+        </TripCardGellerySocial>
+        <RadiusButton buttonType="Collect" />
+        {cardMockData.is_vote ? <RadiusButton buttonType="VOTE NOW" /> : null}
+        <TripCardGelleryShare>
+          <RadiusButton buttonType="siteIcon" />
+        </TripCardGelleryShare>
+      </TripCardGellery>
+      <TripCardDescription>
+        <TripCardDescriptionTitle>
+          {cardMockData.title}
+        </TripCardDescriptionTitle>
+        <TripCardDescriptionLocation>
+          {cardMockData.location}
+          <TripCardDescriptionDate>{cardMockData.date}</TripCardDescriptionDate>
+        </TripCardDescriptionLocation>
+        <TripCardDescriptionAuthor>
+          BY
+          <TripCardDescriptionAuthorUserId>
+            {cardMockData.user_id}
+          </TripCardDescriptionAuthorUserId>
+        </TripCardDescriptionAuthor>
+      </TripCardDescription>
+    </TripCardDiv>
+  );
 }

--- a/src/components/TripCard/TripCardStyles.js
+++ b/src/components/TripCard/TripCardStyles.js
@@ -1,0 +1,124 @@
+import styled from 'styled-components';
+
+const TripCardDiv = styled.div`
+  background: #fff;
+`;
+
+const TripCardGelleryImg = styled.img`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+const TripCardGellery = styled.section`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 292px;
+  padding: 20px;
+  overflow: hidden;
+  background: #000;
+  color: #fff;
+
+  &:hover {
+    > div {
+      opacity: 1;
+    }
+
+    ${TripCardGelleryImg} {
+      transform: scale(1.2);
+      transition: transform 0.5s ease;
+    }
+  }
+
+  > div {
+    opacity: 0;
+  }
+`;
+
+const TripCardGellerySocial = styled.div`
+  position: absolute;
+  left: 20px;
+  top: 20px;
+  display: flex;
+`;
+
+// RadiusButton merge 후 버튼이 잘 나타나지 않을 경우 참고하기위해 주석처리
+// const TripCardGelleryCollect = styled.div`
+//   position: absolute;
+//   padding: 10px;
+//   right: 20px;
+//   top: 20px;
+//   border-radius: 20px;
+//   border: 1px solid #fff;
+// `;
+
+// const TripCardGelleryVote = styled.div`
+//   z-index: 1;
+//   padding: 15px;
+//   border-radius: 40px;
+//   background: #fff;
+//   color: #000;
+// `;
+
+const TripCardGelleryShare = styled.div`
+  position: absolute;
+  right: 20px;
+  bottom: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 1px solid #fff;
+`;
+
+const TripCardDescription = styled.section`
+  padding: 20px;
+`;
+
+const TripCardDescriptionTitle = styled.p`
+  margin-bottom: 25px;
+  font-size: 14px;
+`;
+
+const TripCardDescriptionLocation = styled.p`
+  position: relative;
+  margin-bottom: 26px;
+  font-size: 14px;
+`;
+
+const TripCardDescriptionDate = styled.span`
+  position: absolute;
+  right: 0;
+`;
+
+const TripCardDescriptionAuthor = styled.div`
+  display: flex;
+  align-items: center;
+  padding-top: 10px;
+  border-top: 1px solid #f5f7f6;
+  background: white;
+  font-size: 12px;
+`;
+
+const TripCardDescriptionAuthorUserId = styled.strong`
+  margin-left: 4px;
+`;
+
+export {
+  TripCardDiv,
+  TripCardGellery,
+  TripCardDescription,
+  TripCardGelleryImg,
+  TripCardGellerySocial,
+  TripCardGelleryShare,
+  TripCardDescriptionTitle,
+  TripCardDescriptionLocation,
+  TripCardDescriptionDate,
+  TripCardDescriptionAuthor,
+  TripCardDescriptionAuthorUserId,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Router from './Router';
-import { ThemeProvider } from "styled-components";
+import { ThemeProvider } from 'styled-components';
 import GlobalStyle from './styles/GlobalStyle';
 import theme from './styles/theme';
 
 ReactDOM.render(
-  <>
-    <ThemeProvider theme={theme}>
-      <GlobalStyle />
-      <Router />
-    </ThemeProvider>
-  </>,
+  <ThemeProvider theme={theme}>
+    <GlobalStyle />
+    <Router />
+  </ThemeProvider>,
   document.getElementById('root')
 );

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,5 +1,3 @@
-const theme = {
-
-};
+const theme = {};
 
 export default theme;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- TripList 페이지에서 주로 사용 될 공통 컴포넌트 트립카드 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. TripCard UI 구현
- 상단의 갤러리(TripCardGellery)와 하단의 정보창(TripCardDescription)로 크게 나눠집니다.
- 갤러리는 여행지의 사진을 보여주며, 호버시 사진이 1.2배 커지면서 소셜/찜하기/투표/공유 버튼이 활성화됩니다. isVote를 props로 받아 카드 타입이 랭킹이냐/보트냐에 따라 조건부랜더링 됩니다.
- 정보창은 사진의 제목/여행지/업로드날짜/유저정보 를 표시합니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 전체페이지 제작 후 반복되는 부분을 따로 분리해서 컴포넌트를 만드는 방식이 많았는데, 이번에는 반복되는 부분을 먼저 제작하며 조금 더 리액트적인 개발을 하게 된 것 같습니다.

<br />

## :: 기타 질문 및 특이 사항
