### PR TITLE
[28기 김정현][Add] PaginationButton 영역 구현

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap"
+      rel="stylesheet"
+    />
     <title>방구석 Traveller</title>
   </head>
   <body>

--- a/src/components/Buttons/PaginationButton.js
+++ b/src/components/Buttons/PaginationButton.js
@@ -1,3 +1,0 @@
-export default function PaginationButton() {
-  return <>PaginationButton</>;
-}

--- a/src/components/Buttons/PaginationButtons.js
+++ b/src/components/Buttons/PaginationButtons.js
@@ -1,0 +1,64 @@
+import { cn, cond } from '../../customlib/classNameToggle';
+
+import {
+  PaginationWrapper,
+  PaginationContainer,
+  PaginationBtn,
+  PaginationABtn,
+} from './PaginationButtonsStyle';
+
+export default function PaginationButtons({ nowLocation, paginateData }) {
+  const isMoreThanFivePaginate = nowLocation >= 5 && paginateData.length > 5;
+
+  const mappingPaginationData = paginateData.filter((item, index) => {
+    const isMiddle = index + 2 >= nowLocation && index + 2 <= nowLocation + 2;
+    const isFinalIndex = index + 3 >= nowLocation;
+
+    return nowLocation < 5
+      ? index < 5
+      : nowLocation < paginateData.length
+      ? index === 0 || index === 1 || isMiddle
+      : index === 0 || index === 1 || isFinalIndex;
+  });
+
+  return (
+    <PaginationWrapper>
+      <PaginationContainer>
+        {mappingPaginationData.map((item, index) => {
+          const isActive = nowLocation === item.id;
+
+          return isMoreThanFivePaginate ? (
+            index === 1 ? (
+              <PaginationBtn key={item.id}>...</PaginationBtn>
+            ) : (
+              <PaginationABtn
+                key={item.id}
+                href={`?page=${item.id}`}
+                className={cn('item', cond(isActive, 'active'))}
+              >
+                {item.id}
+              </PaginationABtn>
+            )
+          ) : (
+            <PaginationABtn
+              key={item.id}
+              href={`?page=${item.id}`}
+              className={cn('item', cond(isActive, 'active'))}
+            >
+              {item.id}
+            </PaginationABtn>
+          );
+        })}
+      </PaginationContainer>
+      <PaginationContainer>
+        {nowLocation !== paginateData.length ? (
+          <PaginationABtn className="more" href={`?page=${nowLocation + 1}`}>
+            SHOW ME MORE
+          </PaginationABtn>
+        ) : (
+          ''
+        )}
+      </PaginationContainer>
+    </PaginationWrapper>
+  );
+}

--- a/src/components/Buttons/PaginationButtonsStyle.js
+++ b/src/components/Buttons/PaginationButtonsStyle.js
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+
+const PaginationWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  height: 60px;
+  clear: both;
+  margin: 35px 0;
+  font-size: 16px;
+  overflow: hidden;
+`;
+
+const PaginationContainer = styled.div`
+  width: 25%;
+`;
+
+const PaginationBtn = styled.span`
+  float: left;
+  display: block;
+  width: 60px;
+  height: 60px;
+  margin-right: 1px;
+  line-height: 60px;
+  text-align: center;
+  background-color: #fff;
+  color: #202121;
+  transition: all 0.3s ease-in-out;
+`;
+
+const PaginationABtn = styled(PaginationBtn.withComponent('a'))`
+  text-decoration: none;
+
+  &.item {
+    background-color: #fff;
+
+    &:hover {
+      background-color: #bbb;
+    }
+  }
+
+  &.more {
+    width: 100%;
+    background-color: #000;
+    color: #fff;
+  }
+
+  &.active {
+    background-color: #999;
+  }
+`;
+export {
+  PaginationWrapper,
+  PaginationContainer,
+  PaginationBtn,
+  PaginationABtn,
+};

--- a/src/customlib/classNameToggle.js
+++ b/src/customlib/classNameToggle.js
@@ -1,0 +1,2 @@
+export const cn = (...args) => args.join(' ');
+export const cond = (cond, className) => (cond ? className : '');

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Router from './Router';
-import { ThemeProvider } from "styled-components";
+import { ThemeProvider } from 'styled-components';
 import GlobalStyle from './styles/GlobalStyle';
 import theme from './styles/theme';
 
 ReactDOM.render(
-  <>
-    <ThemeProvider theme={theme}>
-      <GlobalStyle />
-      <Router />
-    </ThemeProvider>
-  </>,
+  <ThemeProvider theme={theme}>
+    <GlobalStyle />
+    <Router />
+  </ThemeProvider>,
   document.getElementById('root')
 );

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -1,8 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyle = createGlobalStyle`
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR&display=swap');
-
 body {
   width: 100vw;
   height: 100vh;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,5 +1,3 @@
-const theme = {
-
-};
+const theme = {};
 
 export default theme;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 페이지네이션 영역을 재사용 컴포넌트화하여 필요한 곳에서 꺼내다 쓰도록 구현합니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 버튼 클릭에 맞는 페이지네이션 기능
- 선택된 번호 버튼은 다른 배경색을 가지게 됩니다.
- 각 번호 버튼은 그 값에 맞는 쿼리 스트링으로 라우트 됩니다.
 - COMPONENT_URL?page={item.id} 의 형태로, 적용되는 컴포넌트에 상관없이 정상적으로 작동할 것으로 예상됩니다.
- 만약 페이지네이션의 길이가 5 이하로 떨어지는 경우, 그만큼의 번호만 렌더링합니다. 
 - Ex) [1,2,3,4] / [1,2,3,4,5] / [1,2,3] 
- 만약 페이지네이션의 길이가 5를 초과하는 경우,
 - 현재 선택된 location이 5 미만이면 1,2,3,4,5만 출력됩니다.
 - location이 5 이상인 경우 [1, ..., location-1, location, location+1]이 출력됩니다.
- SHOW ME MORE 버튼은 현재 선택된 location이 페이지네이션의 끝에 위치한다면 렌더링되지 않습니다.

2. className 생성기
- 커스텀 라이브러리로 생성된 함수입니다.
- cn('hi', cond(condtition,'active') 가 작성되었다면
- condition이 true일 때 'hi active'로, false라면 'hi'로 className이 세팅됩니다.

![image](https://user-images.githubusercontent.com/23470125/148906861-4b693243-2380-486b-92d0-c1345b17dcea.png)

![paginationGif](https://user-images.githubusercontent.com/23470125/148920977-5b9aa5b8-6192-45ca-8364-71bc5c1af8dc.gif)

위의 코드는 Main 영역 코드는 구현화면 확인을 위해 작성되었으며
실제 commit된 사항이 아닙니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 필터 함수와 조금(?) 더 친해졌습니다.
- 조건식이 있는 경우 boolean 상수로 표현하여 깔끔하게 처리하려고 노력했습니다.

<br />

## :: 기타 질문 및 특이 사항
- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시) 
