### PR TITLE
[28기 안현재][Add] TripList페이지 리뷰 반영 완료

### DIFF
--- a/public/data/tripListMockData.json
+++ b/public/data/tripListMockData.json
@@ -1,0 +1,111 @@
+[
+  {
+    "data": "MAIN",
+    "product": {
+      "product_name": "Broadwick Live",
+      "main_image": "https://media.vlpt.us/images/yukyung/post/135d280f-0822-46ac-b299-951a2b956ef6/XL.jpg?w=640",
+      "created_at": "2022년 1월 17일",
+      "user": "user1",
+      "location": "FRANCE",
+      "scores": [
+        { "type": "design", "rate": 82, "circleId": 0 },
+        { "type": "usability", "rate": 71, "circleId": 1 },
+        { "type": "creativity", "rate": 95, "circleId": 2 }
+      ]
+    }
+  },
+  {
+    "data": "NEW",
+    "product": [
+      {
+        "product_id": 1,
+        "product_name": "Azzerad Studios",
+        "main_image": "https://assets.awwwards.com/awards/media/cache/optimize/submissions/2021/11/61a601ba764bb211993959.png",
+        "created_at": "2022년 1월 18일",
+        "user": "user2"
+      },
+      {
+        "product_id": 2,
+        "product_name": "Manoverboard",
+        "main_image": "https://assets.awwwards.com/awards/media/cache/optimize/submissions/2021/11/619d568f87750724692920.png",
+        "created_at": "2022년 1월 17일",
+        "user": "user3"
+      },
+      {
+        "product_id": 3,
+        "product_name": "Azzerad Studios",
+        "main_image": "https://assets.awwwards.com/awards/media/cache/optimize/submissions/2021/11/61a601ba764bb211993959.png",
+        "created_at": "2022년 1월 18일",
+        "user": "user2"
+      },
+      {
+        "product_id": 4,
+        "product_name": "Manoverboard",
+        "main_image": "https://assets.awwwards.com/awards/media/cache/optimize/submissions/2021/11/619d568f87750724692920.png",
+        "created_at": "2022년 1월 17일",
+        "user": "user3"
+      }
+    ]
+  },
+  {
+    "data": "All",
+    "product": [
+      {
+        "product_id": 5,
+        "product_name": "Azzerad Studios",
+        "main_image": "https://assets.awwwards.com/awards/media/cache/optimize/submissions/2021/11/61a601ba764bb211993959.png",
+        "created_at": "2022년 1월 18일",
+        "user": "user2"
+      },
+      {
+        "product_id": 6,
+        "product_name": "Manoverboard",
+        "main_image": "https://assets.awwwards.com/awards/media/cache/optimize/submissions/2021/11/619d568f87750724692920.png",
+        "created_at": "2022년 1월 17일",
+        "user": "user3"
+      },
+      {
+        "product_id": 7,
+        "product_name": "Azzerad Studios",
+        "main_image": "https://assets.awwwards.com/awards/media/cache/optimize/submissions/2021/11/61a601ba764bb211993959.png",
+        "created_at": "2022년 1월 18일",
+        "user": "user2"
+      },
+      {
+        "product_id": 8,
+        "product_name": "Manoverboard",
+        "main_image": "https://assets.awwwards.com/awards/media/cache/optimize/submissions/2021/11/619d568f87750724692920.png",
+        "created_at": "2022년 1월 17일",
+        "user": "user3"
+      },
+      {
+        "product_id": 9,
+        "product_name": "Manoverboard",
+        "main_image": "https://assets.awwwards.com/awards/media/cache/optimize/submissions/2021/11/619d568f87750724692920.png",
+        "created_at": "2022년 1월 17일",
+        "user": "user3"
+      },
+      {
+        "product_id": 10,
+        "product_name": "Manoverboard",
+        "main_image": "https://assets.awwwards.com/awards/media/cache/optimize/submissions/2021/11/619d568f87750724692920.png",
+        "created_at": "2022년 1월 17일",
+        "user": "user3"
+      },
+      {
+        "product_id": 11,
+        "product_name": "Manoverboard",
+        "main_image": "https://assets.awwwards.com/awards/media/cache/optimize/submissions/2021/11/619d568f87750724692920.png",
+        "created_at": "2022년 1월 17일",
+        "user": "user3"
+      },
+      {
+        "product_id": 12,
+        "product_name": "Manoverboard",
+        "main_image": "https://assets.awwwards.com/awards/media/cache/optimize/submissions/2021/11/619d568f87750724692920.png",
+        "created_at": "2022년 1월 17일",
+        "user": "user3"
+      }
+    ]
+  }
+]

--- a/src/components/Buttons/RadiusButton.js
+++ b/src/components/Buttons/RadiusButton.js
@@ -16,7 +16,7 @@ import {
 import styled from 'styled-components';
 
 const BUTTONTYPE_OBJ = {
-  visitsite: 'fillColor',
+  VisitSite: 'fillColor',
   collect: 'hoverEffect',
 };
 
@@ -58,12 +58,15 @@ const Components = styled.button`
     return props.propColor.includes('Icon') ? 'white' : 'black';
   }};
   display: flex;
+  justify-content: center;
   align-items: center;
-  padding: 0 10px;
+  // padding: 0 10px;
+  width: 20px;
   height: 20px;
-  border-radius: 34px;
-  border-color: #202121;
+  border-radius: 50%;
+  border-color: #fff;
   background-color: transparent;
+  color: #fff;
 
   &:hover {
     color: #49c5b6;

--- a/src/components/TripCard/TripCard.js
+++ b/src/components/TripCard/TripCard.js
@@ -5,29 +5,18 @@ import {
   TripCardGelleryImg,
   TripCardDescription,
   TripCardGellerySocial,
-  TripCardGelleryShare,
+  VoteButton,
   TripCardDescriptionTitle,
-  TripCardDescriptionLocation,
   TripCardDescriptionDate,
   TripCardDescriptionAuthor,
   TripCardDescriptionAuthorUserId,
 } from './TripCardStyles';
 
-const cardMockData = {
-  img_url:
-    'https://images.unsplash.com/profile-1446404465118-3a53b909cc82?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=27a346c2362207494baa7b76f5d606e5',
-  is_vote: true,
-  title: '여행지 추천드립니다~',
-  location: '슈투트가르트',
-  date: '2022.01.11',
-  user_id: '유저아이디',
-};
-
-export default function TripCard() {
+export default function TripCard({ listItem }) {
   return (
     <TripCardDiv>
       <TripCardGellery>
-        <TripCardGelleryImg src={cardMockData.img_url} alt="갤러리" />
+        <TripCardGelleryImg src={listItem.main_image} alt="갤러리" />
         <TripCardGellerySocial>
           <RadiusButton buttonType="faceBookIcon" />
           <RadiusButton buttonType="twitterIcon" />
@@ -35,23 +24,18 @@ export default function TripCard() {
           <RadiusButton buttonType="linkedinIcon" />
         </TripCardGellerySocial>
         <RadiusButton buttonType="Collect" />
-        {cardMockData.is_vote ? <RadiusButton buttonType="VOTE NOW" /> : null}
-        <TripCardGelleryShare>
-          <RadiusButton buttonType="siteIcon" />
-        </TripCardGelleryShare>
+        <VoteButton>Vote Now</VoteButton>
+        <RadiusButton buttonType="siteIcon" />
       </TripCardGellery>
       <TripCardDescription>
         <TripCardDescriptionTitle>
-          {cardMockData.title}
+          {listItem.product_name}
         </TripCardDescriptionTitle>
-        <TripCardDescriptionLocation>
-          {cardMockData.location}
-          <TripCardDescriptionDate>{cardMockData.date}</TripCardDescriptionDate>
-        </TripCardDescriptionLocation>
+        <TripCardDescriptionDate>{listItem.created_at}</TripCardDescriptionDate>
         <TripCardDescriptionAuthor>
           BY
           <TripCardDescriptionAuthorUserId>
-            {cardMockData.user_id}
+            {listItem.user}
           </TripCardDescriptionAuthorUserId>
         </TripCardDescriptionAuthor>
       </TripCardDescription>

--- a/src/components/TripCard/TripCardStyles.js
+++ b/src/components/TripCard/TripCardStyles.js
@@ -23,18 +23,41 @@ const TripCardGellery = styled.section`
   color: #fff;
 
   &:hover {
-    > div {
+    > div,
+    button {
       opacity: 1;
     }
 
     ${TripCardGelleryImg} {
       transform: scale(1.2);
       transition: transform 0.5s ease;
+      filter: brightness(50%);
     }
+
+    > button {
+      z-index: 0;
+      color: #fff;
+    }
+  }
+
+  > button {
+    opacity: 0;
+  }
+
+  > button:nth-of-type(1) {
+    position: absolute;
+    right: 20px;
+    top: 20px;
   }
 
   > div {
     opacity: 0;
+  }
+
+  > button:last-of-type {
+    position: absolute;
+    right: 20px;
+    bottom: 20px;
   }
 `;
 
@@ -45,38 +68,18 @@ const TripCardGellerySocial = styled.div`
   display: flex;
 `;
 
-// RadiusButton merge 후 버튼이 잘 나타나지 않을 경우 참고하기위해 주석처리
-// const TripCardGelleryCollect = styled.div`
-//   position: absolute;
-//   padding: 10px;
-//   right: 20px;
-//   top: 20px;
-//   border-radius: 20px;
-//   border: 1px solid #fff;
-// `;
-
-// const TripCardGelleryVote = styled.div`
-//   z-index: 1;
-//   padding: 15px;
-//   border-radius: 40px;
-//   background: #fff;
-//   color: #000;
-// `;
-
-const TripCardGelleryShare = styled.div`
-  position: absolute;
-  right: 20px;
-  bottom: 20px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 1px solid #fff;
+const VoteButton = styled.div`
+  z-index: 1;
+  padding: 15px;
+  border-radius: 40px;
+  background: #fff;
+  color: #000;
 `;
 
+const TripCardGelleryShare = styled.div``;
+
 const TripCardDescription = styled.section`
+  position: relative;
   padding: 20px;
 `;
 
@@ -85,15 +88,14 @@ const TripCardDescriptionTitle = styled.p`
   font-size: 14px;
 `;
 
-const TripCardDescriptionLocation = styled.p`
-  position: relative;
-  margin-bottom: 26px;
-  font-size: 14px;
-`;
-
 const TripCardDescriptionDate = styled.span`
   position: absolute;
-  right: 0;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  padding-top: 10px;
+  border-top: 1px solid #f5f7f6;
+  font-size: 12px;
 `;
 
 const TripCardDescriptionAuthor = styled.div`
@@ -101,7 +103,6 @@ const TripCardDescriptionAuthor = styled.div`
   align-items: center;
   padding-top: 10px;
   border-top: 1px solid #f5f7f6;
-  background: white;
   font-size: 12px;
 `;
 
@@ -115,9 +116,9 @@ export {
   TripCardDescription,
   TripCardGelleryImg,
   TripCardGellerySocial,
+  VoteButton,
   TripCardGelleryShare,
   TripCardDescriptionTitle,
-  TripCardDescriptionLocation,
   TripCardDescriptionDate,
   TripCardDescriptionAuthor,
   TripCardDescriptionAuthorUserId,

--- a/src/pages/TripList/ListDisplay/ListDisplay.js
+++ b/src/pages/TripList/ListDisplay/ListDisplay.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { ListDisplayDiv } from './ListDisplayStyles';
+import SingleList from './SingleList/SingleList';
+
+export default function ListDisplay({ tripLists }) {
+  return (
+    <ListDisplayDiv>
+      {tripLists &&
+        tripLists.map(
+          (list, index) =>
+            index > 0 && (
+              <SingleList
+                key={index}
+                listName={list.section}
+                listItems={list.product}
+              />
+            )
+        )}
+    </ListDisplayDiv>
+  );
+}

--- a/src/pages/TripList/ListDisplay/ListDisplayStyles.js
+++ b/src/pages/TripList/ListDisplay/ListDisplayStyles.js
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+const ListDisplayDiv = styled.div`
+  width: 100%;
+
+  a {
+    text-decoration: none;
+    color: #202121;
+  }
+`;
+
+export { ListDisplayDiv };

--- a/src/pages/TripList/ListDisplay/SingleList/SingleList.js
+++ b/src/pages/TripList/ListDisplay/SingleList/SingleList.js
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import TripCard from '../../../../components/TripCard/TripCard';
+import {
+  SingleListDiv,
+  SingleListName,
+  SingleListUl,
+  LoadMoreButton,
+} from './SingleListStyles';
+
+export default function SingleList({ listName, listItems }) {
+  const [clickedNumber, setClickedNumber] = useState(2);
+  const navigate = useNavigate();
+
+  const updateLimit = () => {
+    const limit = 8;
+    const offset = clickedNumber * 8;
+    const queryString = `?limit=${limit}&offset=${offset}`;
+    navigate(queryString);
+    setClickedNumber(prev => prev + 1);
+  };
+
+  return (
+    <SingleListDiv>
+      <SingleListName>{listName}</SingleListName>
+      <SingleListUl>
+        {listItems &&
+          listItems.map((listItem, index) => {
+            return (
+              <li key={index}>
+                <Link to={`/TripDetail/${listItem.product_id}`}>
+                  <TripCard listItem={listItem} />
+                </Link>
+              </li>
+            );
+          })}
+      </SingleListUl>
+      {listItems.length > 4 && (
+        <LoadMoreButton onClick={updateLimit}>Load More</LoadMoreButton>
+      )}
+    </SingleListDiv>
+  );
+}

--- a/src/pages/TripList/ListDisplay/SingleList/SingleListStyles.js
+++ b/src/pages/TripList/ListDisplay/SingleList/SingleListStyles.js
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+
+const SingleListDiv = styled.div`
+  background: #f5f7f6;
+  padding: 50px 66px;
+`;
+
+const SingleListName = styled.p`
+  font-size: 18px;
+  padding-bottom: 50px;
+`;
+
+const SingleListUl = styled.ul`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 23%));
+  column-gap: 2%;
+  row-gap: 100px;
+`;
+
+const LoadMoreButton = styled.button`
+  display: block;
+  width: 150px;
+  height: 50px;
+  margin: auto;
+  margin-top: 65px;
+  border: none;
+  background: #fff;
+`;
+
+export { SingleListDiv, SingleListName, SingleListUl, LoadMoreButton };

--- a/src/pages/TripList/MainVisual/MainVisual.js
+++ b/src/pages/TripList/MainVisual/MainVisual.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import RadiusButton from '../../../components/Buttons/RadiusButton';
+import RatingCircle from '../../../components/RatingCircle/RatingCircle';
+import {
+  MainVisualDiv,
+  MainVisualImg,
+  MainVisualDateDisplay,
+  MainVisualDate,
+  MainVisualMain,
+  MainVisualMainTitle,
+  MainVisualMainInformation,
+  MainVisualMainInformationUserId,
+  MainVisualMainInformationStrong,
+  MainVisualMainGauges,
+  MainVisualMainGauge,
+  MainVisualMainGaugeLable,
+  MainVisualBottomMenu,
+  MainVisualBottomMenuList,
+  MainVisualJuries,
+  MainVisualJuriesList,
+  MainVisualJury,
+} from './MainVisualStyles';
+
+export default function MainVisual({ mainVisualData }) {
+  return (
+    <MainVisualDiv>
+      {mainVisualData && (
+        <>
+          <MainVisualImg src={mainVisualData.product.main_image} />
+          <MainVisualDateDisplay>
+            Site of the Day{' '}
+            <MainVisualDate>{mainVisualData.product.created_at}</MainVisualDate>
+          </MainVisualDateDisplay>
+          <RadiusButton buttonType="shareIcon" />
+          <MainVisualMain>
+            <MainVisualMainTitle>
+              {mainVisualData.product.product_name}
+            </MainVisualMainTitle>
+            <MainVisualMainInformation>
+              BY{' '}
+              <MainVisualMainInformationUserId>
+                {mainVisualData.product.user}
+              </MainVisualMainInformationUserId>{' '}
+              WITH{' '}
+              <MainVisualMainInformationStrong>
+                {mainVisualData &&
+                  Math.round(
+                    mainVisualData.product.score.reduce(
+                      (acc, curr) => acc + curr.rate,
+                      0
+                    ) / mainVisualData.product.score.length
+                  ) / 10}
+              </MainVisualMainInformationStrong>
+            </MainVisualMainInformation>
+            <MainVisualMainGauges>
+              {mainVisualData &&
+                mainVisualData.product.score.map((division, index) => (
+                  <MainVisualMainGauge key={index}>
+                    <RatingCircle
+                      type={division.type}
+                      rate={division.rate}
+                      circleId={index}
+                    />
+                    <MainVisualMainGaugeLable>
+                      {division.type}
+                    </MainVisualMainGaugeLable>
+                  </MainVisualMainGauge>
+                ))}
+            </MainVisualMainGauges>
+          </MainVisualMain>
+          <MainVisualBottomMenu>
+            <MainVisualBottomMenuList>
+              <RadiusButton buttonType="VisitSite" />
+            </MainVisualBottomMenuList>
+            <MainVisualBottomMenuList>
+              <RadiusButton buttonType="Collect" />
+            </MainVisualBottomMenuList>
+          </MainVisualBottomMenu>
+          <MainVisualJuries>
+            <RadiusButton buttonType="Jury votes" />
+            <MainVisualJuriesList>
+              <MainVisualJury src="https://images.unsplash.com/profile-1446404465118-3a53b909cc82?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=27a346c2362207494baa7b76f5d606e5" />
+              <MainVisualJury src="https://images.unsplash.com/profile-1446404465118-3a53b909cc82?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=27a346c2362207494baa7b76f5d606e5" />
+              <MainVisualJury src="https://images.unsplash.com/profile-1446404465118-3a53b909cc82?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=27a346c2362207494baa7b76f5d606e5" />
+              <MainVisualJury src="https://images.unsplash.com/profile-1446404465118-3a53b909cc82?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=27a346c2362207494baa7b76f5d606e5" />
+              <MainVisualJury src="https://images.unsplash.com/profile-1446404465118-3a53b909cc82?ixlib=rb-0.3.5&q=80&fm=jpg&crop=faces&cs=tinysrgb&fit=crop&h=128&w=128&s=27a346c2362207494baa7b76f5d606e5" />
+            </MainVisualJuriesList>
+          </MainVisualJuries>
+        </>
+      )}
+    </MainVisualDiv>
+  );
+}

--- a/src/pages/TripList/MainVisual/MainVisualStyles.js
+++ b/src/pages/TripList/MainVisual/MainVisualStyles.js
@@ -1,0 +1,144 @@
+import styled from 'styled-components';
+
+const MainVisualImg = styled.img`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  filter: brightness(80%);
+`;
+
+const MainVisualDiv = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100vw;
+  height: 37vw;
+  color: #fff;
+
+  &:hover > ${MainVisualImg} {
+    filter: brightness(50%);
+    transition: filter 0.5s ease;
+  }
+
+  > button {
+    position: absolute;
+    right: 66px;
+    top: 66px;
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+  }
+`;
+
+const MainVisualDateDisplay = styled.span`
+  position: absolute;
+  left: 66px;
+  top: 66px;
+`;
+
+const MainVisualDate = styled.span`
+  margin-left: 5px;
+  font-weight: 300;
+`;
+
+// 버튼 import가 잘 안될 경우 참고하기 위해 주석처리
+// const MainVisualRightTopButton = styled.button`
+//   position: absolute;
+//   right: 66px;
+//   top: 66px;
+//   width: 34px;
+//   height: 34px;
+//   border-radius: 50%;
+// `;
+
+const MainVisualMain = styled.div`
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+`;
+
+const MainVisualMainTitle = styled.p`
+  margin-bottom: 24px;
+  font-size: 38px;
+  font-weight: 800;
+`;
+
+const MainVisualMainInformation = styled.p`
+  margin-bottom: 32px;
+  font-weight: 300;
+`;
+
+const MainVisualMainInformationStrong = styled.strong``;
+
+const MainVisualMainInformationUserId = styled.strong`
+  color: #6dc2b6;
+`;
+
+const MainVisualMainGauges = styled.div`
+  display: flex;
+`;
+
+const MainVisualMainGauge = styled.div`
+  width: 80px;
+  margin: 0 18px;
+`;
+
+const MainVisualMainGaugeLable = styled.ul`
+  padding-top: 8px;
+  font-size: 15px;
+`;
+
+const MainVisualBottomMenu = styled.ul`
+  position: absolute;
+  display: flex;
+  left: 66px;
+  bottom: 66px;
+`;
+
+const MainVisualBottomMenuList = styled.li`
+  margin-right: 15px;
+`;
+
+const MainVisualJuries = styled.div`
+  position: absolute;
+  display: flex;
+  align-items: center;
+  right: 66px;
+  bottom: 66px;
+`;
+
+const MainVisualJuriesList = styled.div`
+  margin-left: 15px;
+  display: felx;
+`;
+
+const MainVisualJury = styled.img`
+  width: 34px;
+  height: 34px;
+  margin-right: 6px;
+  border-radius: 50%;
+  border: none;
+`;
+
+export {
+  MainVisualDiv,
+  MainVisualImg,
+  MainVisualDateDisplay,
+  MainVisualDate,
+  MainVisualMain,
+  MainVisualMainTitle,
+  MainVisualMainInformation,
+  MainVisualMainInformationStrong,
+  MainVisualMainInformationUserId,
+  MainVisualMainGauges,
+  MainVisualMainGauge,
+  MainVisualMainGaugeLable,
+  MainVisualBottomMenu,
+  MainVisualBottomMenuList,
+  MainVisualJuries,
+  MainVisualJuriesList,
+  MainVisualJury,
+};

--- a/src/pages/TripList/TripList.js
+++ b/src/pages/TripList/TripList.js
@@ -1,5 +1,25 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { TripListDiv } from './TripListStyles';
+import MainVisual from './MainVisual/MainVisual';
+import ListDisplay from './ListDisplay/ListDisplay';
 
 export default function TripList() {
-  return <>TripList!</>;
+  const [tripLists, setTripLists] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:3000/data/tripListMockData.json')
+      // fetch('http://040a-211-106-114-186.ngrok.io/products')
+      .then(res => res.json())
+      .then(data => {
+        setTripLists(data);
+        // setTripLists(data.result);
+      });
+  }, []);
+
+  return (
+    <TripListDiv>
+      <MainVisual mainVisualData={tripLists[0]} />
+      <ListDisplay tripLists={tripLists} />
+    </TripListDiv>
+  );
 }

--- a/src/pages/TripList/TripListStyles.js
+++ b/src/pages/TripList/TripListStyles.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const TripListDiv = styled.div`
+  background: #fff;
+`;
+
+export { TripListDiv };


### PR DESCRIPTION
1~3차 커밋 : [WIP 2회 및 ADD] : TripList UI 구현 및 ListDisplay에 mockData 이용한 UI 구현

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 여행사진들의 목록으로 사용할 TripList 페이지를 구현합니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. 상위의 MainVisual 컴포넌트와, 하위의 ListDisplay컴포넌트로 나뉩니다.
- MainVisual컴포넌트는 현재 인기가 많은 여행정보에 관한 데이터를 표시합니다.
- ListDisplay컴포넌트는 사용자가 요청한 여행정보들을 리스트로 표시합니다.

2. MainVisual 컴포넌트
- 현재 핫한 여행정보로, 중앙에는 평점 정보가 표시됩니다. 평점 그래프는 feature/RatingCircle이 rebase되면 추가하겠습니다.
- 좌상단부터 시계방향으로 업로드일자, 업로더, 투표자, 방문/좋아요 버튼이 위치합니다.
- 마우스 오버시 사진의 필터가 짙어져 텍스트 정보를 자세히 볼 수 있게 되고, 클릭 시 해당 여행정보에 투표할 수 있는 페이지로 연결됩니다.

3. ListDisplay 컴포넌트
- 여행정보에 관한 카드들을 표시합니다. 3개의 SingleList로 구성됩니다.
- 3개의 SingleList중 상위 2개는 다득표순과 최신순에 해당하는 내용이 표시되고, 마지막은 사용자가 요청한 여행정보에 해당하는 내용이 표시됩니다.
- SingleList는 상단에 타이틀을 표시하고, 타이틀 아래에 타이틀에 해당하는 카드들을 표시합니다.
- 카드들은 grid로 정렬되며, 3개의 컬럼을 가집니다. 각 카드들은 현재 정확한 내용이 import되지 않고 있으며, feature/TripCard가 rebase되면 표시됩니다.
- 다득표순과 최신순 SingleList는 3개만 표시하게 됩니다. 하지만 마지막 SingleList의 경우 다수의 TripCard가 들어올 수 있고, 이들을 어떻게 띄울지에 대한 내용이 아직 결정되지 않았습니다. 프/백 새로 소통 후, PaginationButton이 rebase되면 많은 수의 TripCard 표시에 대한 내용도 추가구현 하도록 하겠습니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 공통 컴포넌트나 데이터베이스가 없는 상태에서도 mock data활용해서 구현하는 연습을 할 수 있었습니다.

<br />

## :: 기타 질문 및 특이 사항

