### PR TITLE
[28기 김정현][Add] Filter 페이지 로직 작성

### DIFF
--- a/.env
+++ b/.env
@@ -8,4 +8,4 @@ REACT_APP_KAKAO_LOGIN_URL = https://kauth.kakao.com/oauth/authorize?client_id=4b
 
 REACT_APP_KAKAO_TOKEN_URL = https://kauth.kakao.com/oauth/token
 
-REACT_APP_SERVICE_LOGIN_URL = http://c3b0-59-187-202-238.ngrok.io/users/login/kakao/
+REACT_APP_BASE_URL = http://13.125.147.141:8000

--- a/public/data/TripCards1.json
+++ b/public/data/TripCards1.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "1",
+    "name": "나의 게시물",
+    "category": "conti"
+  },
+  {
+    "id": "2",
+    "name": "너의 게시물",
+    "category": "conti"
+  },
+  {
+    "id": "3",
+    "name": "우리의 게시물",
+    "category": "area"
+  },
+  {
+    "id": "4",
+    "name": "모두의 게시물",
+    "category": "eval"
+  },
+  {
+    "id": "5",
+    "name": "그들의 게시물",
+    "category": "feeling"
+  },
+  {
+    "id": "6",
+    "name": "그들의 게시물",
+    "category": "feeling"
+  },
+  {
+    "id": "7",
+    "name": "그들의 게시물",
+    "category": "feeling"
+  },
+  {
+    "id": "8",
+    "name": "그들의 게시물",
+    "category": "feeling"
+  },
+  {
+    "id": "9",
+    "name": "그들의 게시물",
+    "category": "feeling"
+  },
+  {
+    "id": "10",
+    "name": "나의 게시물",
+    "category": "conti"
+  },
+  {
+    "id": "11",
+    "name": "너의 게시물",
+    "category": "conti"
+  },
+  {
+    "id": "12",
+    "name": "우리의 게시물",
+    "category": "area"
+  },
+  {
+    "id": "13",
+    "name": "모두의 게시물",
+    "category": "eval"
+  },
+  {
+    "id": "14",
+    "name": "그들의 게시물",
+    "category": "feeling"
+  },
+  {
+    "id": "15",
+    "name": "그들의 게시물",
+    "category": "feeling"
+  },
+  {
+    "id": "16",
+    "name": "그들의 게시물",
+    "category": "feeling"
+  },
+  {
+    "id": "17",
+    "name": "그들의 게시물",
+    "category": "feeling"
+  },
+  {
+    "id": "18",
+    "name": "그들의 게시물",
+    "category": "feeling"
+  }
+]

--- a/src/Router.js
+++ b/src/Router.js
@@ -3,8 +3,8 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import WithNav from './components/NavOutlet/WithNav';
 import WithoutNav from './components/NavOutlet/WithoutNav';
 import Main from './pages/Main/Main';
-import TripList from './pages/TripList/TripList';
 import TripDetail from './pages/TripDetail/TripDetail';
+import FilterListContainer from './pages/TripFilterLists/FilterListContainer';
 import NotFound from './components/NotFound/NotFound';
 import KakaoRequest from './components/Kakao/KakaoRequest';
 
@@ -19,8 +19,8 @@ export default function Router() {
         <Routes>
           <Route element={<WithNav />}>
             <Route path="/" element={<Main />} />
-            <Route path="/TripList" element={<TripList />} />
-            <Route path="/TripDetail" element={<TripDetail />} />
+            <Route path="/filter" element={<FilterListContainer />} />
+            <Route path="/tripdetail" element={<TripDetail />} />
           </Route>
 
           <Route element={<WithoutNav />}>

--- a/src/components/Buttons/PaginationButtonsStyle.js
+++ b/src/components/Buttons/PaginationButtonsStyle.js
@@ -31,7 +31,6 @@ const PaginationBtn = styled.span`
 const PaginationABtn = styled(PaginationBtn.withComponent('a'))`
   text-decoration: none;
   background-color: ${props => (props.isActive ? '#999' : '#fff')};
-
   &:hover {
     background-color: #bbb;
   }

--- a/src/pages/TripFilterLists/FilterBar.js
+++ b/src/pages/TripFilterLists/FilterBar.js
@@ -1,0 +1,119 @@
+import { useContext } from 'react';
+import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
+
+import { FilterContext } from './FilterListContainer';
+
+import styled from 'styled-components';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFilter, faHistory } from '@fortawesome/free-solid-svg-icons';
+
+const CATEGORY_ENG_URL = {
+  대륙: 'conti',
+  지역: 'area',
+  테마: 'theme',
+  인원: 'person',
+};
+
+export default function FilterBar() {
+  const { isSelectedCategory, handleCategory, filterBarData, resetQuery } =
+    useContext(FilterContext);
+
+  const [searchParams] = useSearchParams();
+
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const moveToBase = () => {
+    resetQuery();
+    navigate(location.pathname);
+  };
+
+  return (
+    <FilterBarContainer>
+      <FilterBarLeft>
+        <FilterUl>
+          <FilterLi>
+            <FontAwesomeIcon icon={faFilter} />
+          </FilterLi>
+          <FilterLi>Filter by</FilterLi>
+          {filterBarData?.map(item => {
+            const categoryName = item.tag_category_name;
+            const categoryEngName = CATEGORY_ENG_URL[item.tag_category_name];
+            return (
+              <FilterItemLi
+                key={categoryName}
+                name={categoryName}
+                isSelectedCategory={isSelectedCategory === categoryEngName}
+                isSelectedTag={searchParams.get(categoryEngName) !== null}
+                onClick={handleCategory}
+              >
+                {searchParams.get(categoryEngName) !== null
+                  ? searchParams.get(categoryEngName)
+                  : categoryName}
+              </FilterItemLi>
+            );
+          })}
+          {searchParams.toString().length > 0 && (
+            <FilterResetLi onClick={moveToBase}>
+              <FontAwesomeIcon icon={faHistory} />
+              RESET FILTERS
+            </FilterResetLi>
+          )}
+        </FilterUl>
+      </FilterBarLeft>
+    </FilterBarContainer>
+  );
+}
+
+const FilterBarContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const FilterBarLeft = styled.section`
+  flex: 1;
+`;
+const FilterUl = styled.ul`
+  display: flex;
+`;
+
+const FilterLi = styled.li`
+  position: relative;
+  height: 69px;
+  padding: 0 20px;
+  line-height: 73px;
+  font-size: 13px;
+  text-transform: uppercase;
+  text-align: center;
+  border-right: 1px solid #e6eaea;
+  white-space: nowrap;
+  transition: all 0.5s;
+`;
+
+const FilterItemLi = styled(FilterLi.withComponent('li'))`
+  background-color: ${props =>
+    (props.isSelectedCategory || props.isSelectedTag) && '#bbb'};
+  font-weight: ${props => props.isSelectedTag && 'bold'};
+
+  &:hover {
+    opacity: 0.5;
+  }
+`;
+
+const FilterResetLi = styled(FilterLi.withComponent('li'))`
+  svg {
+    -webkit-transition: all 0.5s ease;
+    transition: all 0.5s ease;
+    transform: rotate(0deg);
+    margin-right: 10px;
+  }
+
+  &:hover {
+    svg {
+      -webkit-transition: all 0.5s ease;
+      transition: all 0.5s ease;
+      transform: rotate(-720deg);
+    }
+  }
+`;

--- a/src/pages/TripFilterLists/FilterListContainer.js
+++ b/src/pages/TripFilterLists/FilterListContainer.js
@@ -1,0 +1,84 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useFilterToggle from './hook/useFilterToggle';
+import useEditQuery from './hook/useEditQuery';
+
+import styled from 'styled-components';
+
+import FilterBar from './FilterBar';
+import FilterTagsArea from './FilterTagsArea';
+import FilterTripCards from './FilterTripCards';
+import useGetLandscapes from './hook/useGetLandscapes';
+
+export const FilterContext = React.createContext();
+export default function FilterListContainer() {
+  const {
+    isContentVisible,
+    handleContentVisible,
+    handleContentHide,
+    isSelectedCategory,
+    handleCategory,
+  } = useFilterToggle();
+
+  const { queryString, getEachQuery, resetQuery } = useEditQuery();
+
+  const { filterBarData, selectedCategoryData, queryedData } = useGetLandscapes(
+    isSelectedCategory,
+    queryString
+  );
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    navigate(`?${queryString}`);
+  }, [navigate, queryString]);
+
+  return (
+    <FilterContext.Provider
+      value={{
+        isContentVisible,
+        handleContentVisible,
+        handleContentHide,
+        handleCategory,
+        isSelectedCategory,
+        selectedCategoryData,
+        queryString,
+        getEachQuery,
+        filterBarData,
+        queryedData,
+        resetQuery,
+      }}
+    >
+      <FilterBarWrapper>
+        <FilterBar />
+        <FilterTagsArea />
+      </FilterBarWrapper>
+      <FilteredCardsWrapper isContentVisible={isContentVisible}>
+        <FilteredCardsContainer>
+          <FilterTripCards />
+        </FilteredCardsContainer>
+      </FilteredCardsWrapper>
+    </FilterContext.Provider>
+  );
+}
+const FilteredCardsWrapper = styled.div`
+  background-color: #f4f7f6;
+  transition: opacity 0.5s;
+  opacity: ${props => (props.isContentVisible ? 0.5 : 1)};
+  transition: transform 0.5s ease;
+`;
+
+const FilteredCardsContainer = styled.div`
+  max-width: 85%;
+  width: 100%;
+  margin: 0 auto;
+`;
+
+const FilterBarWrapper = styled.div`
+  position: sticky;
+  top: 70px;
+  background-color: #fff;
+  border: 1px solid #e6eaea;
+  z-index: 500;
+  transition: transform 0.5s ease;
+`;

--- a/src/pages/TripFilterLists/FilterTagsArea.js
+++ b/src/pages/TripFilterLists/FilterTagsArea.js
@@ -1,0 +1,94 @@
+import { useContext } from 'react';
+
+import { FilterContext } from './FilterListContainer';
+
+import styled from 'styled-components';
+
+const CATEGORY_ENG_URL = {
+  대륙: 'conti',
+  지역: 'area',
+  테마: 'theme',
+  인원: 'person',
+};
+
+export default function FilterTagsArea() {
+  const {
+    isContentVisible,
+    handleContentHide,
+    selectedCategoryData,
+    getEachQuery,
+    queryString,
+  } = useContext(FilterContext);
+
+  return (
+    <FilterTagsWrapper
+      onMouseLeave={handleContentHide}
+      isContentVisible={isContentVisible}
+    >
+      <FilterTagsContainer>
+        <FilterTags>
+          {selectedCategoryData?.map(categoryName => {
+            const tagNames = categoryName.tags;
+            return tagNames.map(item => {
+              return (
+                <FilterTagBtn
+                  key={item.name}
+                  name={item.name}
+                  onClick={e =>
+                    getEachQuery(
+                      e,
+                      CATEGORY_ENG_URL[categoryName.tag_category_name]
+                    )
+                  }
+                  isSelectedTag={decodeURI(queryString).includes(
+                    item.name.replace('/', '%2F')
+                  )}
+                >
+                  {item.name}
+                </FilterTagBtn>
+              );
+            });
+          })}
+        </FilterTags>
+      </FilterTagsContainer>
+    </FilterTagsWrapper>
+  );
+}
+
+const FilterTagsWrapper = styled.div`
+  position: absolute;
+  width: 100%;
+  max-height: calc(100vh-140px);
+  background-color: #fcfcfc;
+  padding: 30px 0 37px 30px;
+  opacity: ${props => (props.isContentVisible ? 1 : 0)};
+  visibility: ${props => (props.isContentVisible ? 'visibility' : 'hidden')};
+  transition: all 0.5s;
+`;
+
+const FilterTagsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  word-break: break-all;
+`;
+
+const FilterTags = styled.section`
+  display: flex;
+`;
+
+const FilterTagBtn = styled.button`
+  width: 85px;
+  height: 50px;
+  background-color: ${props => {
+    return props.isSelectedTag ? '#1d1d1d' : 'transparent';
+  }};
+  color: ${props => {
+    return props.isSelectedTag ? 'white' : 'black';
+  }};
+  font-weight: ${props => {
+    return props.isSelectedTag ? 700 : 400;
+  }};
+  border: 0.5px solid lightgrey;
+  border-radius: 50px 50px;
+  margin-right: 10px;
+`;

--- a/src/pages/TripFilterLists/FilterTripCards.js
+++ b/src/pages/TripFilterLists/FilterTripCards.js
@@ -1,0 +1,73 @@
+import { useContext } from 'react';
+import { useLocation, Link } from 'react-router-dom';
+
+import { FilterContext } from './FilterListContainer';
+
+import styled from 'styled-components';
+
+import PaginationButtons from '../../components/Buttons/PaginationButtons';
+import TripCard from '../../components/TripCard/TripCard';
+
+import { FilterTripSkeletonCard } from './FilterTripSkeletonCard';
+import useCreatePaginate from './hook/useCreatePaginate';
+
+export default function TripCards() {
+  const { queryString, getEachQuery, queryedData } = useContext(FilterContext);
+  const { paginateData } = useCreatePaginate(queryedData);
+  const location = useLocation();
+
+  const nowLocation = location.search.split('page=')[1];
+
+  return (
+    <TripCardsWrapper>
+      {queryedData ? (
+        queryedData.length ? (
+          <>
+            <TripCardsGrid>
+              {queryedData.map(item => (
+                <Link
+                  to={`../tripdetail/${item.product_id}`}
+                  key={item.product_id}
+                >
+                  <TripCard listItem={item} />
+                </Link>
+              ))}
+            </TripCardsGrid>
+            <PaginationButtons
+              nowLocation={nowLocation ? Number(nowLocation) : 1}
+              paginateData={paginateData}
+              queryString={queryString}
+              getEachQuery={getEachQuery}
+            />
+          </>
+        ) : (
+          <TripCardsNotFound>검색 결과가 없습니다.</TripCardsNotFound>
+        )
+      ) : (
+        <TripCardsGrid>
+          <FilterTripSkeletonCard />
+        </TripCardsGrid>
+      )}
+    </TripCardsWrapper>
+  );
+}
+
+const TripCardsWrapper = styled.div`
+  opacity: 1;
+  z-index: 1;
+  padding: 50px 0;
+`;
+
+const TripCardsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 23%));
+  column-gap: 2%;
+  row-gap: 100px;
+`;
+
+const TripCardsNotFound = styled.div`
+  display: flex;
+  height: calc(100vh - 437px);
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/pages/TripFilterLists/FilterTripSkeletonCard.js
+++ b/src/pages/TripFilterLists/FilterTripSkeletonCard.js
@@ -1,0 +1,114 @@
+import styled from 'styled-components';
+
+const defaultSkeletonCards = [1, 2, 3, 4];
+
+export function FilterTripSkeletonCard() {
+  return (
+    <>
+      {defaultSkeletonCards.map(item => {
+        return (
+          <TripCardSkeletonWrapper key={item}>
+            <TripCardImageSkeleton />
+            <TripCardSkeletonWhiteWrapper>
+              <TripCardSkeletonTitle />
+              <TripCardSkeletonLocation />
+              <TripCardSkeletonDate />
+            </TripCardSkeletonWhiteWrapper>
+            <TripCardSkeletonAuthorWrapper>
+              <TripCardSkeletonAuthorContainer>
+                <TripCardSkeletonAuthor />
+              </TripCardSkeletonAuthorContainer>
+            </TripCardSkeletonAuthorWrapper>
+          </TripCardSkeletonWrapper>
+        );
+      })}
+    </>
+  );
+}
+
+const TripCardSkeletonAnimation = styled.div`
+  background-image: linear-gradient(
+      100deg,
+      rgba(255, 255, 255, 0),
+      rgba(255, 255, 255, 0.3) 50%,
+      rgba(255, 255, 255, 0) 100%
+    ),
+    linear-gradient(lightgrey 100%, transparent 0);
+  background-repeat: no-repeat;
+  background-position: 0 0;
+  background-size: 100% 100%;
+
+  animation: TripCardSkeletonAnimate 1s infinite;
+
+  @keyframes TripCardSkeletonAnimate {
+    0% {
+      opacity: 0.5;
+    }
+
+    100% {
+      opacity: 1;
+    }
+  }
+`;
+
+const TripCardSkeletonWrapper = styled.div`
+  background: rgba(255, 255, 255, 0);
+`;
+
+const TripCardImageSkeleton = styled(
+  TripCardSkeletonAnimation.withComponent('div')
+)`
+  width: 100%;
+  height: 292px;
+`;
+
+const TripCardSkeletonWhiteWrapper = styled.section`
+  position: relative;
+  width: 90%;
+  padding: 20px 5%;
+  background-color: #fff;
+`;
+
+const TripCardSkeletonTitle = styled(
+  TripCardSkeletonAnimation.withComponent('div')
+)`
+  width: 30%;
+  height: 20px;
+`;
+
+const TripCardSkeletonLocation = styled(
+  TripCardSkeletonAnimation.withComponent('div')
+)`
+  display: inline-block;
+  width: 20%;
+  height: 20px;
+  margin-top: 10px;
+`;
+
+const TripCardSkeletonDate = styled(
+  TripCardSkeletonAnimation.withComponent('div')
+)`
+  display: inline-block;
+  margin-left: 55%;
+  width: 25%;
+  height: 20px;
+`;
+
+const TripCardSkeletonAuthorWrapper = styled(
+  TripCardSkeletonWhiteWrapper.withComponent('div')
+)`
+  padding: 10px 5%;
+`;
+
+const TripCardSkeletonAuthorContainer = styled.div`
+  width: 100%;
+  border-top: 1px solid #f5f7f6;
+`;
+
+const TripCardSkeletonAuthor = styled(
+  TripCardSkeletonAnimation.withComponent('div')
+)`
+  width: 25%;
+  height: 20px;
+  margin-top: 10px;
+`;

--- a/src/pages/TripFilterLists/hook/useCreatePaginate.js
+++ b/src/pages/TripFilterLists/hook/useCreatePaginate.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+
+export default function useCreatePaginate(data) {
+  const [paginateData, setPaginateData] = useState([]);
+
+  useEffect(() => {
+    if (data) {
+      const paginateNumber = data.length / 8;
+      const paginateNumberObj = [];
+      let start = 0;
+
+      while (start < paginateNumber) {
+        paginateNumberObj.push({
+          id: ++start,
+        });
+      }
+
+      setPaginateData(paginateNumberObj);
+    }
+  }, [data, setPaginateData]);
+
+  return { paginateData };
+}

--- a/src/pages/TripFilterLists/hook/useEditQuery.js
+++ b/src/pages/TripFilterLists/hook/useEditQuery.js
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export default function useEditQuery() {
+  const [queryString, setQueryString] = useState('');
+
+  const [searchParams] = useSearchParams();
+
+  const getEachQuery = (e, categoryName) => {
+    const name = e.target.getAttribute('name');
+
+    searchParams.get(categoryName) !== name
+      ? searchParams.set(categoryName, name)
+      : searchParams.delete(categoryName);
+
+    setQueryString(searchParams.toString());
+  };
+
+  const resetQuery = () => {
+    setQueryString('');
+  };
+
+  return { queryString, getEachQuery, resetQuery };
+}

--- a/src/pages/TripFilterLists/hook/useFetch.js
+++ b/src/pages/TripFilterLists/hook/useFetch.js
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+export default function useFetch(url, fetcher) {
+  const [data, setData] = useState(false);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    try {
+      fetcher(url).then(data => {
+        setData(data);
+      });
+    } catch (err) {
+      setError(err);
+    }
+  }, []);
+
+  return { data, error };
+}

--- a/src/pages/TripFilterLists/hook/useFilterToggle.js
+++ b/src/pages/TripFilterLists/hook/useFilterToggle.js
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+
+export default function useFilterToggle() {
+  const [isContentVisible, setIsContentVisible] = useState(false);
+  const [isSelectedCategory, setIsSelectedCategory] = useState('');
+  const [categories, setCategories] = useState([]);
+
+  const handleContentVisible = () => {
+    setIsContentVisible(true);
+  };
+
+  const handleContentHide = () => {
+    setIsSelectedCategory('');
+    setCategories([]);
+    setIsContentVisible(false);
+  };
+
+  const handleCategory = e => {
+    const name = e.target.getAttribute('name');
+
+    setCategories(current => {
+      const newList = [...current];
+      newList.includes(name)
+        ? newList.splice(newList.indexOf(name, 1))
+        : newList.push(name);
+      return newList;
+    });
+
+    setIsSelectedCategory(isSelectedCategory !== name ? name : '');
+  };
+
+  useEffect(() => {
+    categories.length !== 0 ? handleContentVisible() : handleContentHide();
+  }, [categories.length]);
+
+  return {
+    isContentVisible,
+    handleContentVisible,
+    handleContentHide,
+    isSelectedCategory,
+    handleCategory,
+  };
+}

--- a/src/pages/TripFilterLists/hook/useGetLandscapes.js
+++ b/src/pages/TripFilterLists/hook/useGetLandscapes.js
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react';
+
+export default function useGetLandscapes(isSelectedCategory, queryString) {
+  const [queryedData, setQueryedData] = useState();
+  const [filterBarData, setFilterBarData] = useState();
+  const [selectedCategoryData, setSelectedCategoryData] = useState();
+
+  useEffect(() => {
+    fetch(`http://e4c2-211-106-114-186.ngrok.io/products/categories`)
+      .then(res => res.json())
+      .then(data => setFilterBarData(data.result));
+  }, []);
+
+  useEffect(() => {
+    fetch(`http://e4c2-211-106-114-186.ngrok.io/products?${queryString}`)
+      .then(res => res.json())
+      .then(data => {
+        setQueryedData(data.result);
+      });
+  }, [queryString]);
+
+  useEffect(() => {
+    filterBarData &&
+      setSelectedCategoryData(current => {
+        return filterBarData.filter(item => {
+          return item.tag_category_name === isSelectedCategory;
+        });
+      });
+  }, [isSelectedCategory, filterBarData]);
+
+  return { queryedData, filterBarData, selectedCategoryData };
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
 - Filter페이지가 선택된 필터에 맞게 Card를 뿌리도록 구현합니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 필터 바
- 각각의 필터는 따로 사용될 수 있으며, 동시에 함께 조건으로 사용될 수 있습니다.
- 초기에는 각각 카테고리 이름으로 렌더링되지만 조건이 될 태그버튼을 클릭하면 해당 태그의 이름으로 필터 버튼의 이름이 변경되며, 현재 적용된 필터버튼은 흑색으로 점등됩니다.
- 클릭된 카테고리와 필터 값은 객체배열에 담기며, qs 패키지의 도움을 통해 자연스럽게 쿼리스트링이 되어 그 즉시 navigate 됩니다.
- 최상단에서 쿼리스트링을 파싱해와 해당 url에 맞는 fetch를 진행하여 데이터를 받아오도록 만들 예정입니다.
-  
![filterQueryActivity](https://user-images.githubusercontent.com/23470125/149623678-4b4a6849-8600-4b85-b411-9785cb3a86ad.gif)

2. useEditQuery

쿼리를 조합하여 반환해주는 커스텀 훅입니다.

![image](https://user-images.githubusercontent.com/23470125/149624695-032e38c3-a77c-4a99-bcd6-814279b4cf59.png)

getEachQuery는 {쿼리 키 : 쿼리 값} 형태로 저장될 queryObj state를 업데이트하는 onClick method입니다.

```
<button name='ASC' onClick={e=> getEachQuery(e,'order')}> 오름차순 </button>
```

첫 번째 인자는 쿼리의 값이 될, 태그의 name을 받아오기 위한 e 이며
두 번째 인자는 쿼리의 키 값을 넣어주면 됩니다.

onClick event가 발생하면 쿼리 객체 배열이 업데이트됩니다.

```
queryObj = {
 conti : 'asia'
 area : '산'
 eval : 'good'
 feeling : 'calm'
 page : 1
}
```

객체 배열은 위와 같은 형태로 업데이트되고, 이 queryObj를 dependency array로 삼아 queryString을 조합합니다.

```
?conti=asia&area=산&eval=good&page=1
```

위와 같은 형태에서, 공통된 부분은 " key=value& " 라는 것에 착안하여

```
1. 쿼리 스트링이 있는 경우, 무조건 '?'로 시작하므로, navigate(`?${queryString}') 으로 제어하면 '?'는 사용될 필요가 없다.
2. 객체를 배열로 변환하면 0번째가 쿼리의 키, 1번째가 쿼리의 값이 된다.
3. 즉, queryObj[0] + '=' + queryObj[1] + '&' 를 하면 " key=value& " 의 형태가 되며 이것을 반복하면 된다.
4. 마지막 루프에서 '&'이 하나가 남는데 이것은 slice(0,-1)을 이용해 떼어낸다.
```

위의 순서에 따라 reduce 함수로 queryString을 갱신하고, 반환합니다.

또한 queryObj가 기준이 되어 url이 변경되므로

필터가 리셋될 경우를 고려하여 setQueryObj 또한 함께 반환하여 Reset Filter 버튼에 적용시켜주었습니다.

presentQuery는 현재 쿼리스트링을 반환하는데, 쿼리에 한글이 포함될 가능성을 고려하여 decodeURI를 걸어주었습니다.

Filter 창의 tag 버튼들의 disabled 여부를 결정해줄 때 쿼리에 해당 값이 포함되어 있느냐, 그렇지 않느냐를 구분할 때 사용합니다.

당장은 한 가지의 컴포넌트에서만 사용하기에 따로 내려줄 이유는 없다고 볼 수도 있지만, 만약 여러 컴포넌트가 이 훅을 사용하고, 현재 쿼리가 어떤지 확인해야된다면 필요할 수도 있다는 생각에 포함했습니다.

현재는 각 카테고리당 한개의 태그만 선택될 수 있도록만 해두었지만

추후 기획에 따라 여러개의 태그가 선택될 수 있도록 하는 방향으로 변경될 수 있습니다.

//

![image](https://user-images.githubusercontent.com/23470125/149808923-5f37385e-e621-447c-a93f-9bc59dc9300f.png)

useEditQuery 간소화 버전 업데이트합니다!

사용 방법은 기존과 다른 것이 없습니다.

그리고, react router dom의 useSearchParams를 이용해 무려 35줄의 코드를 20줄로 바꾸는 경사를 얻었습니다...




3. 스켈레톤 UI

![filterListSkeleton](https://user-images.githubusercontent.com/23470125/149662076-ac211e93-1b26-4530-afed-5a9fbbc911f4.gif)


<br />


## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 이 컴포넌트에는 전역으로 공유되어야 할 것이 많은 것은 아니지만, useContext를 사용하여 보다 보기 좋게 다듬어보았습니다.

<br />

## :: 기타 질문 및 특이 사항

백엔드와의 통신을 통해 쿼리에 따라 데이터가 다르게 세팅되는지만 확인되면 완료됩니다.

저는 보통 클릭 이벤트가 발생하는 태그에 name 속성을 붙여서 제어하곤 하는데, 이 부분 혹 권장되는 방향이 될 수 있을지 궁금하고

전반적으로 혹시 과하게 state를 내리진 않았는지, 필터가 보였다가 사라지는 부분을 커스텀 훅으로 분기했는데 해당 코드를 좀 더 다듬을 수 있는지에 대해 고민 중입니다.

