### PR TITLE
[28기 김정현][Modify] PaginationButtons 상호작용을 위한 수정 / 스타일 수정

### DIFF
--- a/src/components/Buttons/PaginationButtons.js
+++ b/src/components/Buttons/PaginationButtons.js
@@ -1,13 +1,16 @@
-import { cn, cond } from '../../customlib/classNameToggle';
-
 import {
   PaginationWrapper,
   PaginationContainer,
   PaginationBtn,
   PaginationABtn,
+  PaginationNextBtn,
 } from './PaginationButtonsStyle';
 
-export default function PaginationButtons({ nowLocation, paginateData }) {
+export default function PaginationButtons({
+  nowLocation,
+  paginateData,
+  getEachQuery,
+}) {
   const isMoreThanFivePaginate = nowLocation >= 5 && paginateData.length > 5;
 
   const mappingPaginationData = paginateData.filter((item, index) => {
@@ -33,8 +36,8 @@ export default function PaginationButtons({ nowLocation, paginateData }) {
             ) : (
               <PaginationABtn
                 key={item.id}
-                href={`?page=${item.id}`}
-                className={cn('item', cond(isActive, 'active'))}
+                isActive={isActive}
+                onClick={e => getEachQuery(e, 'page')}
               >
                 {item.id}
               </PaginationABtn>
@@ -42,8 +45,9 @@ export default function PaginationButtons({ nowLocation, paginateData }) {
           ) : (
             <PaginationABtn
               key={item.id}
-              href={`?page=${item.id}`}
-              className={cn('item', cond(isActive, 'active'))}
+              name={item.id}
+              isActive={isActive}
+              onClick={e => getEachQuery(e, 'page')}
             >
               {item.id}
             </PaginationABtn>
@@ -52,9 +56,12 @@ export default function PaginationButtons({ nowLocation, paginateData }) {
       </PaginationContainer>
       <PaginationContainer>
         {nowLocation !== paginateData.length ? (
-          <PaginationABtn className="more" href={`?page=${nowLocation + 1}`}>
+          <PaginationNextBtn
+            name={nowLocation + 1}
+            onClick={e => getEachQuery(e, 'page')}
+          >
             SHOW ME MORE
-          </PaginationABtn>
+          </PaginationNextBtn>
         ) : (
           ''
         )}

--- a/src/components/Buttons/PaginationButtonsStyle.js
+++ b/src/components/Buttons/PaginationButtonsStyle.js
@@ -5,7 +5,7 @@ const PaginationWrapper = styled.div`
   justify-content: space-between;
   height: 60px;
   clear: both;
-  margin: 35px 0;
+  padding: 35px 0;
   font-size: 16px;
   overflow: hidden;
 `;
@@ -25,32 +25,28 @@ const PaginationBtn = styled.span`
   background-color: #fff;
   color: #202121;
   transition: all 0.3s ease-in-out;
+  cursor: pointer;
 `;
 
 const PaginationABtn = styled(PaginationBtn.withComponent('a'))`
   text-decoration: none;
+  background-color: ${props => (props.isActive ? '#999' : '#fff')};
 
-  &.item {
-    background-color: #fff;
-
-    &:hover {
-      background-color: #bbb;
-    }
-  }
-
-  &.more {
-    width: 100%;
-    background-color: #000;
-    color: #fff;
-  }
-
-  &.active {
-    background-color: #999;
+  &:hover {
+    background-color: #bbb;
   }
 `;
+
+const PaginationNextBtn = styled(PaginationBtn.withComponent('a'))`
+  width: 100%;
+  background-color: #000;
+  color: #fff;
+`;
+
 export {
   PaginationWrapper,
   PaginationContainer,
   PaginationBtn,
   PaginationABtn,
+  PaginationNextBtn,
 };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
-다른 컴포넌트에서 유연하게 사용할 수 있도록 수정합니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 현재 URL의 Query를 확인하여 페이지네이션 쿼리가 적절히 합쳐지도록 수정하였습니다.
2. 직접 구현한 useEditQuery와 연동되어 해당 컴포넌트가 선택한 페이지의 버튼이 훅으로 전달되어 쿼리스트링이 조합되는 방식입니다.  FilterLists branch가 병합되면 정상적으로 작동합니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 커스텀으로 쿼리를 다뤘던 부분인데, 다른 컴포넌트에서 들어올 쿼리스트링에 대해 생각하지 않고 짜서 낭패를 본 케이스입니다. 따라서 이 컴포넌트의 쿼리 조합 로직을 모두 삭제하고, 따로 구현해둔 커스텀 훅인 useEditQuery와 연결시켰더니 이번엔 해당 훅에서 범용성을 고려하지 않은 문제가 발생했습니다. 다행히 잘 수정되어 정상적으로 작동되고 있고, 커스텀 훅이든 재사용 컴포넌트든 공통적으로 쓰일 것에 대해서 처음부터 설계를 잘 해야겠다고 반성했습니다.

<br />

## :: 기타 질문 및 특이 사항
- 스타일 컴포넌트를 사용하면서, 기존에 쓰던 cn,cond 방식을 버리고 props에 따라 style이 컨트롤 되도록 해보았는데요, 그럼에도 불구하고 클래스 이름을 따로 작성해야되는 경우가 발생할 수도 있을까요?
